### PR TITLE
refactor(typings): Getting rid of @types/redux-actions as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "@types/react": "^16.0.38",
     "@types/react-dom": "^16.0.4",
     "@types/redux": "^3.6.31",
-    "@types/redux-actions": "^2.2.4",
     "colors": "^1.1.2",
     "commitizen": "^2.9.6",
     "coveralls": "^3.0.0",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 // tslint:disable:no-any
-import { Action, ActionFunction1 } from 'redux-actions';
 import { ComponentClass, ComponentType } from 'react';
 
 // Diff / Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
@@ -9,6 +8,20 @@ export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
 
 export type InputQuery<TProps, TResult> = (props: TProps) => Promise<TResult>;
 export type ActionQuery<TResult> = (...args: any[]) => Promise<TResult>;
+
+// Taken from redux-actions
+export interface BaseAction {
+  type: string;
+}
+
+// Taken from redux-actions
+export interface Action<Payload> extends BaseAction {
+  payload?: Payload;
+  error?: boolean;
+}
+
+// Taken from redux-actions
+export type ActionFunction1<T1, R> = (t1: T1) => R;
 
 export type ResultActions<T> = Array<ActionFunction1<T, Action<T>>>;
 


### PR DESCRIPTION
Getting rid of @types/redux-actions dependency. 