### PR TITLE
fix(buildQueryKey): Make anonymous queries keys unique

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "querier",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Simple declarative data layer for React applications",
   "keywords": [
     "react",
@@ -89,6 +89,7 @@
     "@types/enzyme": "^3.1.9",
     "@types/invariant": "^2.2.29",
     "@types/jest": "^22.0.0",
+    "@types/js-md5": "0.4.2",
     "@types/node": "^9.3.0",
     "@types/prop-types": "^15.5.2",
     "@types/react": "^16.0.38",
@@ -132,6 +133,7 @@
   },
   "dependencies": {
     "invariant": "^2.2.3",
+    "js-md5": "0.7.3",
     "prop-types": "^15.6.0",
     "shallowequal": "1.0.2"
   }

--- a/src/utils/buildQueryKey.ts
+++ b/src/utils/buildQueryKey.ts
@@ -1,8 +1,7 @@
+import md5 from 'js-md5';
+
 // tslint:disable-next-line
 export const buildQueryKey = (query: Function, props?: any) => {
-  if (props) {
-    return `${query.name}:${JSON.stringify(props)}`;
-  } else {
-    return `${query.name}`;
-  }
+  const queryKey = `${query.name || 'anonymous'}[${md5(query.toString())}]`;
+  return props ? `${queryKey}:${JSON.stringify(props)}` : queryKey;
 };

--- a/test/utils/buildQueryKey.test.ts
+++ b/test/utils/buildQueryKey.test.ts
@@ -2,21 +2,54 @@ import { buildQueryKey } from '../../src/utils/buildQueryKey';
 
 describe('Utils', () => {
   describe('buildQueryKey', () => {
-    const testQuery = () => { return; };
+    const testQuery = () => {
+      return;
+    };
 
-    it('return query name if props provided', () => {
-      expect(buildQueryKey(testQuery)).toBe('testQuery');
+    it('returns query name and query prop if no props provided', () => {
+      expect(buildQueryKey(testQuery)).toBe('testQuery[65b876fd4521ead1f877ff5b830355f2]');
     });
 
-    it('return key build from query name and stringified props', () => {
+    it('returns key build from query name and stringified props', () => {
       const props = {
         a: 1,
         b: 'b prop',
-        c: () => { return; },
+        c: () => {
+          return;
+        },
         d: new Map()
       };
 
-      expect(buildQueryKey(testQuery, props)).toBe('testQuery:{"a":1,"b":"b prop","d":{}}');
+      expect(buildQueryKey(testQuery, props)).toBe(
+        'testQuery[65b876fd4521ead1f877ff5b830355f2]:{"a":1,"b":"b prop","d":{}}'
+      );
+    });
+  });
+
+  describe('anonymous queries', () => {
+    const props = {
+      a: 1,
+      b: 'b prop',
+      c: () => {
+        return;
+      },
+      d: new Map()
+    };
+
+    it('returns md5 hashed query with anonymous identifier', () => {
+      const queryKeyA = buildQueryKey(() => {});
+      const queryKeyB = buildQueryKey(() => {});
+      const queryKeyC = buildQueryKey(() => {}, props);
+      const queryKeyD = buildQueryKey((a: string) => {});
+
+      expect(queryKeyA).toContain('anonymous');
+      expect(queryKeyB).toContain('anonymous');
+      expect(queryKeyC).toContain('anonymous');
+      expect(queryKeyD).toContain('anonymous');
+
+      expect(queryKeyA).toEqual(queryKeyB);
+      expect(queryKeyA).not.toEqual(queryKeyC);
+      expect(queryKeyA).not.toEqual(queryKeyD);
     });
   });
 });

--- a/test/utils/queryDescriptorBuilders.test.ts
+++ b/test/utils/queryDescriptorBuilders.test.ts
@@ -50,7 +50,7 @@ describe('queryDescriptorBuilders', () => {
         inputQuery
       });
 
-      expect(queryDesciptor.inputQuery.key).toBe('testQuery');
+      expect(queryDesciptor.inputQuery.key).toBe('testQuery[44ce398bb016359ccff354315583ed5f]');
     });
 
     it('handles empty query definitions', () => {
@@ -85,7 +85,7 @@ describe('queryDescriptorBuilders', () => {
         actionQuery
       });
 
-      expect(queryDesciptor.actionQuery.key).toBe('testQuery');
+      expect(queryDesciptor.actionQuery.key).toBe('testQuery[44ce398bb016359ccff354315583ed5f]');
     });
 
     it('handles empty query definitions', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,6 +131,10 @@
   version "22.2.3"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.2.3.tgz#0157c0316dc3722c43a7b71de3fdf3acbccef10d"
 
+"@types/js-md5@0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@types/js-md5/-/js-md5-0.4.2.tgz#95b39911e2081bf2915436e61cc345e12459e5bb"
+
 "@types/lodash@4.14.99":
   version "4.14.99"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.99.tgz#e6e10c0a4cc16c7409b3181f1e66880d2fb7d4dc"
@@ -2912,6 +2916,10 @@ jest@^22.4.2:
   dependencies:
     import-local "^1.0.0"
     jest-cli "^22.4.3"
+
+js-md5@0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/js-md5/-/js-md5-0.7.3.tgz#b4f2fbb0b327455f598d6727e38ec272cd09c3f2"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Starting from now all queries keys stored in Querier are build from query name and md5 has of the
serialized query function. For anonymous queries query name is set to anonymous. This change is
driven by the fact, that there can be muliple query functions with the same name but different
bodies. Also up until now if there was more than one anonymous query in a Querier connected comonent
or multiple anonymous queries accepting the same props, then the data resolving was
non-deterministic.

fix #9