### PR TITLE
fix(cache): Making action queries hot by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Having this knowledge you can start building UI abstractions over this API to di
 Also, there is a [`combineStates(states: StatesType): QueryStateType`](./src/utils/combineStates.ts) utility that will calculate derived status of multiple query states.
 
 ## Caching
-By default, all queries executed by Querier are cached. However, there are cases, when you want your queries to be executed every time instead of served from cache. To do so you need to declare your query as `hot` in your data dependencies definition passed to `withData` HOC:
+By default, all **input** queries executed by Querier are cached. However, there are cases, when you want your queries to be executed every time instead of served from cache. To do so you need to declare your query as `hot` in your data dependencies definition passed to `withData` HOC:
 
 ```ts
 const searchComponentQueries = {
@@ -298,6 +298,8 @@ const searchComponentQueries = {
   }
 }
 ```
+
+For action queriers set `hot: false` to make them cacheable.
 
 Querier cache is not persistent - you need to take care of this by yourself. `QuerierProvider` component accepts `querier: QuerierType` property that can be initialised using querier store that you have cached in e.g. local storage.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "querier",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Simple declarative data layer for React applications",
   "keywords": [
     "react",

--- a/src/utils/queryDescriptorBuilders.ts
+++ b/src/utils/queryDescriptorBuilders.ts
@@ -44,10 +44,12 @@ export const actionQueryDescriptorsBuilder = <TActionQueries>(
       const wrappedQuery = (...args: any[]) => query(...args);
 
       let queryDescriptor: Partial<WrappedActionQueries<TActionQueries>> = {};
-
       queryDescriptor[actionQueryProp] = {
         query: wrappedQuery,
-        hot: !!actionQueries[actionQueryProp].hot,
+        hot:
+          actionQueries[actionQueryProp].hot === undefined
+            ? true
+            : !!actionQueries[actionQueryProp].hot,
         key: buildQueryKey(actionQueries[actionQueryProp].query)
       };
 

--- a/test/utils/queryDescriptorBuilders.test.ts
+++ b/test/utils/queryDescriptorBuilders.test.ts
@@ -6,7 +6,7 @@ import {
 
 describe('queryDescriptorBuilders', () => {
   describe('inputQueryDescriptorsBuilder', () => {
-    it('auguments query hot and resultActions properties if not present in definition', () => {
+    it('auguments query hot to false and resultActions properties if not present in definition', () => {
       const inputQuery: InputQueryDefinition<{}, {}> = {
         query: async (props: {}) => {
           return {};
@@ -59,7 +59,7 @@ describe('queryDescriptorBuilders', () => {
   });
 
   describe('actionQueryDescriptorsBuilder', () => {
-    it('auguments query hot property if not present in definition', () => {
+    it('auguments query hot property to true if not present in definition', () => {
       const actionQuery = {
         query: async (props: {}) => {
           return {};
@@ -70,7 +70,7 @@ describe('queryDescriptorBuilders', () => {
         actionQuery
       });
 
-      expect(queryDesciptor.actionQuery).toHaveProperty('hot', false);
+      expect(queryDesciptor.actionQuery).toHaveProperty('hot', true);
       expect(queryDesciptor.actionQuery).not.toHaveProperty('resultActions');
     });
 


### PR DESCRIPTION
As action queries should be a subject of caching rarely, they are not cached by default now. You can
still make them cacheable by setting `hot: false` in query definition