### PR TITLE
feat(withData HOC): Adding input queries executors to withData decorated component's props

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ const repositoryDetailsQueries = {
 // Second, use withData HOC
 export default withData(repositoryDetailsQueries)(YourComponent);
 ```
+
+#### Input queries executors - manually invoking input queries
+
+Input queries are automatically invoked when component's props change. However, in some cases there is a need to re-invoke input query for the same set of props. To do so, each query is passed to the component in `inputQueries` property, that contain each query's executor. In the case of the example above, the executor  for `repository` input query is accessible by:
+
+```js
+this.props.inputQueries.repository.fire()
+```
+
 #### Input queries key notes
 - Input queries are fired when component mounts
 - **Input queries always receive component's full set of props** as argument

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "querier",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Simple declarative data layer for React applications",
   "keywords": [
     "react",

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,11 @@ export type InputQueriesResults<TInputQueries> = {
   [TProp in keyof TInputQueries]: TInputQueries[TProp] | null
 };
 
+export type InputQueriesProps<TInputQueries> = {
+  [TProp in keyof TInputQueries]: {
+    fire: () => void;
+  }
+};
 export type ActionQueriesProps<TActionQueries> = {
   [TProp in keyof TActionQueries]: (...args: any[]) => Promise<TActionQueries[TProp]>
 };
@@ -89,6 +94,7 @@ export type WithDataProps<TProps, TInputQueries, TActionQueries> = {
 } & {
   results: InjectedResults<TInputQueries, TActionQueries>;
   actionQueries: ActionQueriesProps<TActionQueries>;
+  inputQueries: InputQueriesProps<TInputQueries>;
   states: InjectedStates<TInputQueries, TActionQueries>;
 };
 

--- a/test/withDataFactory.test.tsx
+++ b/test/withDataFactory.test.tsx
@@ -252,6 +252,35 @@ describe('withDataFactory', () => {
 
   });
 
+  it('passes input queries executors to component', async () => {
+    const querySpy = jest.fn();
+    const query = spiedQuery(querySpy);
+    const inputQueries = mockWrappedQuery('inputQueryTest', query, null, false, 'queryKey');
+
+    const ComponentWithData = withDataFactory<ComponentProps, {}, ComponentActionQueries>({
+      inputQueries: {
+        inputQueryTest: {
+          query,
+          resultActions: null,
+          hot: false,
+          key: ''
+        }
+      }
+    })(Component);
+
+    const wrapper = mount(
+      <QuerierProviderMock querier={new Querier()}>
+        <ComponentWithData prop1="yay" />
+      </QuerierProviderMock>
+    );
+
+    expect(querySpy).toBeCalled();
+    expect(wrapper.find(Component).props().inputQueries).toHaveProperty('inputQueryTest');
+    // tslint:disable-next-line
+    expect(wrapper.find(Component).props().inputQueries['inputQueryTest']).toHaveProperty('fire');
+
+  });
+
   it('handles pure function components', () => {
     const querySpy = jest.fn();
     const renderSpy = jest.fn();


### PR DESCRIPTION
Starting from now, decorated component contains `inputQueries` property that contains input queries
executors. This enables Querier's user to manually re-invoke input queries with the current
properites' set.