### PR TITLE
fix(WithData HOC): Fixing memory leaks possibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "querier",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Simple declarative data layer for React applications",
   "keywords": [
     "react",

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,14 +77,19 @@ export type InputQueriesProps<TInputQueries> = {
     fire: () => void;
   }
 };
+
 export type ActionQueriesProps<TActionQueries> = {
   [TProp in keyof TActionQueries]: (...args: any[]) => Promise<TActionQueries[TProp]>
 };
 
 export type InjectedStates<TInputQueries, TActionQueries> = {
-  [P in keyof TActionQueries]: QueryStateType
+  [P in keyof TActionQueries]: QueryStateType | null
 } &
-  { [P in keyof TInputQueries]: QueryStateType };
+  { [P in keyof TInputQueries]: QueryStateType | null };
+
+export type InputQueryExecutor = {
+  fire: () => void;
+};
 
 export type InjectedResults<TInputQueries, TActionQueries> = InputQueriesResults<TInputQueries> &
   InputQueriesResults<TActionQueries>;


### PR DESCRIPTION
Right now, component will not be updated, when it has already unmpuonted, but Querier subscription
has flushed update. Also, fixed issue with inut queries executors creating subscriptions on
component render. This might have caused memory leaks, because subscriptions were not cancelled on
render. Right now input queries subscriptions are created on moint and update only.