### PR TITLE
fix(Querier): Fixed issue with Querier fetched data not beind passed …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "querier",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Simple declarative data layer for React applications",
   "keywords": [
     "react",

--- a/src/Querier.ts
+++ b/src/Querier.ts
@@ -6,7 +6,6 @@ import {
   QuerierState,
   QuerierStoreType,
   QuerierType,
-  QueryStateType,
   QuerierStateEntry,
   ResultActions
 } from './types';

--- a/src/withDataFactory.tsx
+++ b/src/withDataFactory.tsx
@@ -56,13 +56,15 @@ export const withDataFactory = <TProps, TInputQueries, TActionQueries>(queries: 
       }
 
       componentDidMount() {
-        this.fireInputQueries();
         this.hasMounted = true;
+        this.fireInputQueries();
       }
 
       componentDidUpdate(prevProps: TProps) {
+
         if (!shallowequal(this.props, prevProps)) {
           this.unsubscribeQuerier();
+          this.initializePropsToQueryKeysMap();
           this.initializeInputQueriesExecutors();
           this.fireInputQueries(true);
         }
@@ -113,6 +115,7 @@ export const withDataFactory = <TProps, TInputQueries, TActionQueries>(queries: 
           results: {},
           states: {}
         };
+
         this.propsToQueryKeysMap.forEach((queryKey, prop) => {
           const queryStoreEntry = this.context.querier.getEntry(queryKey);
           const result: {


### PR DESCRIPTION
…down correctly

On props update decorated component received states and results from previous query execution,
meaning the state was Success and the results were already there even though the query was hot. Moreover, in some cases the querie's Active state was not passed down to component resulting in a situation, where there was only Success/Error state accessible to decorated component.