### PR TITLE
fix(Querier): Fix issue with cached results notifications being fired…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "querier",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Simple declarative data layer for React applications",
   "keywords": [
     "react",

--- a/src/Querier.ts
+++ b/src/Querier.ts
@@ -88,7 +88,6 @@ export class Querier implements QuerierType {
     // TODO: add typings
     const listeners = this.listeners.get(queryKey);
     this.listeners.set(queryKey, listeners ? [...listeners, listener] : [listener]);
-
     return () => {
       const _listeners = this.listeners.get(queryKey);
       if (_listeners) {
@@ -185,7 +184,11 @@ export class Querier implements QuerierType {
       (possibleQueryResult.result || possibleQueryResult.state.state === QuerierState.Active)
     ) {
       this.logger.log('Serving query from cache', possibleQueryResult);
-      this.notify(queryKey);
+
+      // Schedule notification to next frame, to allow component that requested the data to mount
+      window.requestAnimationFrame(() => {
+        this.notify(queryKey);
+      });
       return true;
     }
 

--- a/src/withDataFactory.tsx
+++ b/src/withDataFactory.tsx
@@ -168,8 +168,8 @@ export const withDataFactory = <TProps, TInputQueries, TActionQueries>(queries: 
                   actionQueryParams
                 )}`;
                 this.propsToQueryKeysMap.set(actionQueryProp, queryKey);
+                this.querierSubscriptions.push(querier.subscribe(queryKey, this.handleQuerierUpdate));
 
-                querier.subscribe(queryKey, this.handleQuerierUpdate);
                 querier.sendQuery({
                   query,
                   queryKey,

--- a/test/Querier.test.ts
+++ b/test/Querier.test.ts
@@ -161,7 +161,7 @@ describe('Querier', () => {
         };
       });
 
-      it('serves from cache if query result is available', async () => {
+      it('serves from cache if query result is available', done => {
         const store: QuerierStoreType = createStoreMock();
 
         const querier = new Querier(store);
@@ -174,11 +174,16 @@ describe('Querier', () => {
           queryKey: queryKey
         });
 
-        expect(querySpy).not.toBeCalled();
-        expect(listenerSpy).toBeCalledWith(store[queryKey]);
+        // We expect notification from Querier to be fired. It is fired using rAF,
+        // so we need to delay expects to next frame
+        setTimeout(() => {
+          expect(querySpy).not.toBeCalled();
+          expect(listenerSpy).toBeCalledWith(store[queryKey]);
+          done();
+        }, 0);
       });
 
-      it('serves from cache if query is active', () => {
+      it('serves from cache if query is active', done => {
         const store: QuerierStoreType = createStoreMock({ state: QuerierState.Active });
 
         const querier = new Querier(store);
@@ -192,8 +197,13 @@ describe('Querier', () => {
           queryKey: queryKey
         });
 
-        expect(querySpy).not.toBeCalled();
-        expect(listenerSpy).toBeCalledWith(store[queryKey]);
+        // We expect notification from Querier to be fired. It is fired using rAF,
+        // so we need to delay expects to next frame
+        setTimeout(() => {
+          expect(querySpy).not.toBeCalled();
+          expect(listenerSpy).toBeCalledWith(store[queryKey]);
+          done();
+        }, 0);
       });
 
       it('ignores cache if query is set to hot', async () => {

--- a/test/setupTests.js
+++ b/test/setupTests.js
@@ -2,3 +2,4 @@ const Enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
 
 Enzyme.configure({ adapter: new Adapter() });
+global.requestAnimationFrame = callback => setTimeout(callback, 0);


### PR DESCRIPTION
… before component mounted

In some cases(e.g. when serving action query cached result) the subscribed component would not
rerender as subscription notification was fired before the compponent actually mounted. To avoid
that, the notification is delayed to next frame (using rAF) to make sure the component has actually
mounted.